### PR TITLE
Add autotools

### DIFF
--- a/recipes/capnproto/all/conandata.yml
+++ b/recipes/capnproto/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "0.8.0":
     url: "https://github.com/capnproto/capnproto/archive/v0.8.0.tar.gz"
     sha256: "6d8b43a7ec2a764b4dfe4139a7cdd070ad9057f106898050d9f4db3754b98820"
+patches:
+  "0.8.0":
+    - base_path: source_subfolder
+      patch_file: patches/0001-disable-tests.patch

--- a/recipes/capnproto/all/patches/0001-disable-tests.patch
+++ b/recipes/capnproto/all/patches/0001-disable-tests.patch
@@ -1,7 +1,19 @@
 diff --git a/c++/Makefile.am b/c++/Makefile.am
-index fe40a0a..3520e74 100644
+index fe40a0a..93c172b 100644
 --- a/c++/Makefile.am
 +++ b/c++/Makefile.am
+@@ -251,9 +251,9 @@ MAYBE_KJ_TLS_TESTS=
+ endif
+ 
+ if LITE_MODE
+-lib_LTLIBRARIES = libkj.la libkj-test.la libcapnp.la
++lib_LTLIBRARIES = libkj.la libcapnp.la
+ else
+-lib_LTLIBRARIES = libkj.la libkj-test.la libkj-async.la libkj-http.la $(MAYBE_KJ_TLS_LA) $(MAYBE_KJ_GZIP_LA) libcapnp.la libcapnp-rpc.la libcapnp-json.la libcapnpc.la
++lib_LTLIBRARIES = libkj.la libkj-async.la libkj-http.la $(MAYBE_KJ_TLS_LA) $(MAYBE_KJ_GZIP_LA) libcapnp.la libcapnp-rpc.la libcapnp-json.la libcapnpc.la
+ endif
+ 
+ libkj_la_LIBADD = $(PTHREAD_LIBS)
 @@ -425,158 +425,3 @@ endif LITE_MODE
  #  src/capnp/serialize-snappy*
  #  src/capnp/benchmark/...

--- a/recipes/capnproto/all/patches/0001-disable-tests.patch
+++ b/recipes/capnproto/all/patches/0001-disable-tests.patch
@@ -1,0 +1,163 @@
+diff --git a/c++/Makefile.am b/c++/Makefile.am
+index fe40a0a..3520e74 100644
+--- a/c++/Makefile.am
++++ b/c++/Makefile.am
+@@ -425,158 +425,3 @@ endif LITE_MODE
+ #  src/capnp/serialize-snappy*
+ #  src/capnp/benchmark/...
+ #  src/capnp/compiler/...
+-
+-# Tests ==============================================================
+-
+-test_capnpc_inputs =                                           \
+-  src/capnp/test.capnp                                         \
+-  src/capnp/test-import.capnp                                  \
+-  src/capnp/test-import2.capnp                                 \
+-  src/capnp/compat/json-test.capnp
+-
+-test_capnpc_outputs =                                          \
+-  src/capnp/test.capnp.c++                                     \
+-  src/capnp/test.capnp.h                                       \
+-  src/capnp/test-import.capnp.c++                              \
+-  src/capnp/test-import.capnp.h                                \
+-  src/capnp/test-import2.capnp.c++                             \
+-  src/capnp/test-import2.capnp.h                               \
+-  src/capnp/compat/json-test.capnp.c++                         \
+-  src/capnp/compat/json-test.capnp.h
+-
+-if USE_EXTERNAL_CAPNP
+-
+-test_capnpc_middleman: $(test_capnpc_inputs)
+-	@$(MKDIR_P) src
+-	$(CAPNP) compile --src-prefix=$(srcdir)/src -o$(CAPNPC_CXX):src -I$(srcdir)/src $$(for FILE in $(test_capnpc_inputs); do echo $(srcdir)/$$FILE; done)
+-	touch test_capnpc_middleman
+-
+-else
+-
+-test_capnpc_middleman: capnp$(EXEEXT) capnpc-c++$(EXEEXT) $(test_capnpc_inputs)
+-	@$(MKDIR_P) src
+-	./capnp$(EXEEXT) compile --src-prefix=$(srcdir)/src -o./capnpc-c++$(EXEEXT):src -I$(srcdir)/src $$(for FILE in $(test_capnpc_inputs); do echo $(srcdir)/$$FILE; done)
+-	touch test_capnpc_middleman
+-
+-endif
+-
+-$(test_capnpc_outputs): test_capnpc_middleman
+-
+-BUILT_SOURCES = $(test_capnpc_outputs)
+-
+-check_LIBRARIES = libcapnp-test.a
+-libcapnp_test_a_SOURCES =                                      \
+-  src/capnp/test-util.c++                                      \
+-  src/capnp/test-util.h
+-nodist_libcapnp_test_a_SOURCES = $(test_capnpc_outputs)
+-
+-if LITE_MODE
+-
+-check_PROGRAMS = capnp-test
+-compiler_tests =
+-capnp_test_LDADD = libcapnp-test.a libcapnp.la libkj-test.la libkj.la
+-
+-else !LITE_MODE
+-
+-check_PROGRAMS = capnp-test capnp-evolution-test capnp-afl-testcase
+-heavy_tests =                                                  \
+-  src/kj/async-test.c++                                        \
+-  src/kj/async-xthread-test.c++                                \
+-  src/kj/async-unix-test.c++                                   \
+-  src/kj/async-unix-xthread-test.c++                           \
+-  src/kj/async-win32-test.c++                                  \
+-  src/kj/async-win32-xthread-test.c++                          \
+-  src/kj/async-io-test.c++                                     \
+-  src/kj/parse/common-test.c++                                 \
+-  src/kj/parse/char-test.c++                                   \
+-  src/kj/std/iostream-test.c++                                 \
+-  src/kj/compat/url-test.c++                                   \
+-  src/kj/compat/http-test.c++                                  \
+-  $(MAYBE_KJ_GZIP_TESTS)                                       \
+-  $(MAYBE_KJ_TLS_TESTS)                                        \
+-  src/capnp/canonicalize-test.c++                              \
+-  src/capnp/capability-test.c++                                \
+-  src/capnp/membrane-test.c++                                  \
+-  src/capnp/schema-test.c++                                    \
+-  src/capnp/schema-loader-test.c++                             \
+-  src/capnp/schema-parser-test.c++                             \
+-  src/capnp/dynamic-test.c++                                   \
+-  src/capnp/stringify-test.c++                                 \
+-  src/capnp/serialize-async-test.c++                           \
+-  src/capnp/serialize-text-test.c++                            \
+-  src/capnp/rpc-test.c++                                       \
+-  src/capnp/rpc-twoparty-test.c++                              \
+-  src/capnp/ez-rpc-test.c++                                    \
+-  src/capnp/compat/json-test.c++                               \
+-  src/capnp/compiler/lexer-test.c++                            \
+-  src/capnp/compiler/type-id-test.c++
+-capnp_test_LDADD =                                             \
+-  libcapnp-test.a                                              \
+-  libcapnpc.la                                                 \
+-  libcapnp-rpc.la                                              \
+-  libcapnp-json.la                                             \
+-  libcapnp.la                                                  \
+-  libkj-http.la                                                \
+-  $(MAYBE_KJ_GZIP_LA)                                          \
+-  $(MAYBE_KJ_TLS_LA)                                           \
+-  libkj-async.la                                               \
+-  libkj-test.la                                                \
+-  libkj.la                                                     \
+-  $(ASYNC_LIBS)                                                \
+-  $(PTHREAD_LIBS)
+-
+-endif !LITE_MODE
+-
+-capnp_test_CPPFLAGS = -Wno-deprecated-declarations
+-capnp_test_SOURCES =                                           \
+-  src/kj/common-test.c++                                       \
+-  src/kj/memory-test.c++                                       \
+-  src/kj/refcount-test.c++                                     \
+-  src/kj/array-test.c++                                        \
+-  src/kj/string-test.c++                                       \
+-  src/kj/string-tree-test.c++                                  \
+-  src/kj/table-test.c++                                        \
+-  src/kj/map-test.c++                                          \
+-  src/kj/encoding-test.c++                                     \
+-  src/kj/exception-test.c++                                    \
+-  src/kj/debug-test.c++                                        \
+-  src/kj/arena-test.c++                                        \
+-  src/kj/units-test.c++                                        \
+-  src/kj/tuple-test.c++                                        \
+-  src/kj/one-of-test.c++                                       \
+-  src/kj/function-test.c++                                     \
+-  src/kj/io-test.c++                                           \
+-  src/kj/mutex-test.c++                                        \
+-  src/kj/time-test.c++                                         \
+-  src/kj/threadlocal-test.c++                                  \
+-  src/kj/filesystem-test.c++                                   \
+-  src/kj/filesystem-disk-test.c++                              \
+-  src/kj/test-test.c++                                         \
+-  src/capnp/common-test.c++                                    \
+-  src/capnp/blob-test.c++                                      \
+-  src/capnp/endian-test.c++                                    \
+-  src/capnp/endian-fallback-test.c++                           \
+-  src/capnp/endian-reverse-test.c++                            \
+-  src/capnp/layout-test.c++                                    \
+-  src/capnp/any-test.c++                                       \
+-  src/capnp/message-test.c++                                   \
+-  src/capnp/encoding-test.c++                                  \
+-  src/capnp/orphan-test.c++                                    \
+-  src/capnp/serialize-test.c++                                 \
+-  src/capnp/serialize-packed-test.c++                          \
+-  src/capnp/fuzz-test.c++                                      \
+-  $(heavy_tests)
+-
+-if !LITE_MODE
+-capnp_evolution_test_LDADD = libcapnpc.la libcapnp.la libkj.la
+-capnp_evolution_test_SOURCES = src/capnp/compiler/evolution-test.c++
+-
+-capnp_afl_testcase_LDADD = libcapnp-test.a libcapnp-rpc.la libcapnp.la libkj.la libkj-async.la
+-capnp_afl_testcase_SOURCES = src/capnp/afl-testcase.c++
+-endif !LITE_MODE
+-
+-if LITE_MODE
+-TESTS = capnp-test
+-else !LITE_MODE
+-TESTS = capnp-test capnp-evolution-test src/capnp/compiler/capnp-test.sh
+-endif !LITE_MODE


### PR DESCRIPTION
TODO: Fix cmake function for capnp executable, when lite option is enabled.