### PR TITLE
qt/5.x.x: Fix compilation error for gcc 11

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -24,5 +24,7 @@ patches:
       base_path: "qt5/qtdeclarative"
     - patch_file: "patches/f830b86.diff"
       base_path: "qt5/qtwebengine/src/3rdparty"
+    - patch_file: "patches/fix-gcc-11.diff"
+      base_path: "qt5/qtwebengine/src/3rdparty"
     - patch_file: "patches/dece6f5.diff"
       base_path: "qt5/qtbase"

--- a/recipes/qt/5.x.x/patches/fix-gcc-11.diff
+++ b/recipes/qt/5.x.x/patches/fix-gcc-11.diff
@@ -1,0 +1,10 @@
+--- a/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.h
++++ b/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.h
+@@ -19,6 +19,7 @@ 
+ 
+ #include <stddef.h>
+ #include <stdint.h>
++#include <limits>
+ 
+ #include <unordered_map>
+ #include <vector>


### PR DESCRIPTION
Hello,

I created this PR as suggested by @[ericLemanissier](https://github.com/ericLemanissier).
I did [this PR upstream](https://github.com/conan-io/conan-center-index/pull/9382) but it failed to build and he said that your branch should fix it.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
