### PR TITLE
[arg_router] Update to v1.4.0 plus Windows fixes

### DIFF
--- a/recipes/arg_router/all/conandata.yml
+++ b/recipes/arg_router/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.0":
+    url: "https://github.com/cmannett85/arg_router/archive/refs/tags/v1.4.0.tar.gz"
+    sha256: "33d086a41d441bacee886041432169ed02c3da17669c77e69506ba94344530f1"
   "1.3.0":
     url: "https://github.com/cmannett85/arg_router/archive/refs/tags/v1.3.0.tar.gz"
     sha256: "4ef2ec923046c26d65b19f06630b3180a81189362d8920a68113c7d921ca968b"

--- a/recipes/arg_router/all/conanfile.py
+++ b/recipes/arg_router/all/conanfile.py
@@ -22,23 +22,23 @@ class ArgRouterConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        return "17"
+        return "20" if str(self.settings.compiler) == "msvc" else "17"
 
     @property
     def _min_compilers_version(self):
         return {
             "apple-clang": "10",
-            "clang": "5",
-            "gcc": "10",
+            "clang": "10",
+            "gcc": "9",
             "msvc": "191",
-            "Visual Studio": "15",
+            "Visual Studio": "17",
         }
 
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("boost/1.81.0")
+        self.requires("boost/1.74.0")
         self.requires("span-lite/0.10.3")
 
     def package_id(self):
@@ -84,5 +84,3 @@ class ArgRouterConan(ConanFile):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
         self.cpp_info.requires = ["boost::headers", "span-lite::span-lite"]
-        if self.settings.os == "Windows":
-            self.cpp_info.defines.append("NOMINMAX")

--- a/recipes/arg_router/all/test_package/CMakeLists.txt
+++ b/recipes/arg_router/all/test_package/CMakeLists.txt
@@ -5,4 +5,10 @@ find_package(arg_router REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE arg_router::arg_router)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+    target_compile_options(${PROJECT_NAME} PRIVATE /Zc:__cplusplus)
+else()
+    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+endif()

--- a/recipes/arg_router/config.yml
+++ b/recipes/arg_router/config.yml
@@ -1,4 +1,6 @@
 versions:
   # Newer versions at the top
+  "1.4.0":
+    folder: all
   "1.3.0":
     folder: all


### PR DESCRIPTION
* Update the package version to v1.4.0
* Use a minimum of C++20 when building with MSVC, otherwise it's C++17
* Set the minimum gcc version and Boost version to that tested against the upstream CI
* Added a missing /Zc:__cplusplus MSVC flag

The minimum clang version is probably too high, but setting it to what I test in my CI removes the version as potential problem.  I can lower it after.